### PR TITLE
Mex right click upgrade-pause and let ACU cap structures.

### DIFF
--- a/hook/lua/options/options.lua
+++ b/hook/lua/options/options.lua
@@ -14,6 +14,7 @@ table.insert(options.ui.items,
 
 table.insert(options.gameplay.items,
     {
+        tip = '"On click" - left click the mex. Mex will start upgrading and will not pause.\n"On right click" - select an engineer or commander and right click the mex, it will upgrade-pause. Mexes will unpause automatically when assisted.\n"Auto" - All mexes will upgrade-pause automatically. Mexes will unpause automatically when assisted.',
         title = "EM: MEX upgrade-pause",
         key = 'em_mexes',
         type = 'toggle',
@@ -21,8 +22,9 @@ table.insert(options.gameplay.items,
         custom = {
             states = {
                 {text = "<LOC _Off>", key = 0 },
-                {text = "On click", key = 'click' },
-                {text = "Auto", key = 'auto' },
+                {text = "On click", key = 'click'},
+                {text = "On right click", key = 'r_click'},
+                {text = "Auto", key = 'auto'},
             },
         },
     })

--- a/hook/lua/options/options.lua
+++ b/hook/lua/options/options.lua
@@ -22,9 +22,9 @@ table.insert(options.gameplay.items,
         custom = {
             states = {
                 {text = "<LOC _Off>", key = 0 },
-                {text = "On click", key = 'click'},
-                {text = "On right click", key = 'r_click'},
-                {text = "Auto", key = 'auto'},
+                {text = "On click", key = 'click' },
+                {text = "On right click", key = 'r_click' },
+                {text = "Auto", key = 'auto' },
             },
         },
     })

--- a/hook/lua/ui/game/commandmode.lua
+++ b/hook/lua/ui/game/commandmode.lua
@@ -23,8 +23,8 @@ function CapStructure(command)
         return 
     end
 
-    -- check if we have engineers
-    local units = EntityCategoryFilterDown(categories.ENGINEER, command.Units)
+    -- check if we have engineers or commander
+    local units = EntityCategoryFilterDown(categories.ENGINEER, command.Units) or EntityCategoryFilterDown(categories.COMMAND, command.Units)
     if not units[1] then return end
 
     -- check if we have a building that we target

--- a/hook/lua/ui/game/commandmode.lua
+++ b/hook/lua/ui/game/commandmode.lua
@@ -65,7 +65,13 @@ function CapStructure(command)
                     or isTech3
                 ) and not buildFabs
 
-            local upgradeMex = options['em_mexes'] == 'click' and not isUpgrading and (isTech1 or isTech2)
+            -- upgrade mex if left-clicked with em_mexes == 'click' or right-clicked with em_mexes == 'r_click'
+            local upgradeMex =
+                (
+                    (options['em_mexes'] == 'click' and command.CommandType != "Guard")
+                    or (options['em_mexes'] == 'r_click' and command.CommandType == "Guard")
+                    and not isUpgrading and (isTech1 or isTech2)
+                )
 
             if upgradeMex then
                 local eco = structure:GetEconData()


### PR DESCRIPTION
This will allow us to right click a bunch of mexes with engineers and have only those mexes upgrade-pause.
Also I noticed that when we select "On click" option mexes do not pause. Didn't touch that.